### PR TITLE
Make example implementation

### DIFF
--- a/src/start/urql/cacheExchange.ts
+++ b/src/start/urql/cacheExchange.ts
@@ -4,18 +4,20 @@ import { TranslationsDocument } from 'graphql/generated';
 
 const cacheExchange = cacheExchangeURQL({
   keys: {
-    Pagination: () => 'Pagination',
-    TranslationPaginationResponse: () => 'TranslationPaginationResponse',
-    UserPaginationResponse: () => 'UserPaginationResponse',
+    Pagination: () => null,
+    TranslationPaginationResponse: () => null,
+    UserPaginationResponse: () => null,
   },
   updates: {
     Mutation: {
       translationDelete: (_result, { id }, cache) => {
-        console.log(cache.readQuery({ query: TranslationsDocument }));
-        cache.updateQuery({ query: TranslationsDocument }, (data) => {
-          console.log(data, id);
-          return data;
-        });
+        // cache.invalidate evicts the entity from the cache, do note that I'm not sure about the typename I'm making an example
+        // https://formidable.com/open-source/urql/docs/graphcache/custom-updates/#cacheinvalidate
+        cache.invalidate({ __typename: 'Translation', id });
+        // to use cache.readQuery you'll probably have to use the variables passed into this document.
+        // cache.inspectFields might be worth looking at:
+        // https://formidable.com/open-source/urql/docs/graphcache/custom-updates/#cacheinspectfields
+        // console.log(cache.readQuery({ query: TranslationsDocument }));
       },
     },
   },


### PR DESCRIPTION
Hey,

I opened this PR so we can have an open discussion and maybe find ways where our documentation is confusing, feel free to point anything in the docs/implementation that is confusing and we can discuss it.

As a general rule of thumb when we are normalizing we'll take a document and traverse it:

```graphql
query {
  todos (from: 0, limit: 24) {
    edges {
      pageInfo { hasNextPage }
      nodes { id text }
    }
  }
}
```

so here when a response comes back we can normalize like this:

```js
const cache {
  'Query.todos(from: 0, limit: 24).edges': { pageInfo: { hasNextPage: value }, nodes: ['Todo:x'] },
  'Todo:x.id': 'x',
  'Todo:x.text': 'Hello world',
}

```

You might wonder why pageInfo is embedded while nodes isn't (using this to illustrate), well pageInfo can't be uniquely identified so we have to embed it, this is normal because for instance in your case `Pagination` is an arbitrary JSON object that won't be updated/doesn't represent a database entity.
The nodes however we can uniquely identify by the combination of their `__typename` and unique identifier.

The keying attribute of graphCache allows us to tell the cache that we are dealing with an embeddable entity rather than a key that we can't derive, since we are automatically using `id` or `_id` you can customize a custom key or tell it that we are embedding.

In your case you told the cache that you are using a static-key for all these entities which makes all of the `pageInfo` objects connected to each other which makes it very confusing for the cache.

In the update or readQuery part you are calling for your list but we aren't passing any variables, this means that we won't get back all the queries that have variables outside of your paged parameters.